### PR TITLE
Check types

### DIFF
--- a/src/check_types.test.ts
+++ b/src/check_types.test.ts
@@ -1,10 +1,10 @@
-import { assertEquals } from "./deps.ts";
+import { assertEquals, Range } from "./deps.ts";
 import { matched_types, mismatches } from "./check_types.ts";
 
 Deno.test("will not complain on types without an associated pacakge", () => {
   const mismatches = matched_types([
-    ["@types/node", "~8.11"],
-    ["typescript", "^4.9"],
+    { name: "@types/node", range: new Range("~8.11") },
+    { name: "typescript", range: new Range("^4.9") },
   ]);
 
   assertEquals(mismatches, []);
@@ -12,30 +12,54 @@ Deno.test("will not complain on types without an associated pacakge", () => {
 
 Deno.test("will find potential mismatches on types with an associated pacakge", () => {
   const matched = matched_types([
-    ["@types/react", "~16.1"],
-    ["react", "^16.1"],
+    { name: "@types/react", range: new Range("~16.1") },
+    { name: "react", range: new Range("^16.1") },
   ]);
 
   assertEquals(matched, [
-    { name: "react", range: "^16.1", type_range: "~16.1" },
+    {
+      name: "react",
+      range: new Range("^16.1"),
+      type_range: new Range("~16.1"),
+    },
   ]);
 });
 
 Deno.test("will error on caret ranges", () => {
   const mismatched = mismatches(matched_types([
-    ["@types/react", "^17"],
-    ["react", "^17"],
+    { name: "@types/react", range: new Range("^17") },
+    { name: "react", range: new Range("^17") },
   ]));
 
   assertEquals(mismatched, [
-    ["react", "Invalid caret (^) notation. Use tilde (~) instead"],
+    ["react", "Invalid notation. Only pinned and tilde (~) ranges allowed"],
   ]);
+});
+
+Deno.test("will error on wide ranges", () => {
+  const mismatched = mismatches(matched_types([
+    { name: "@types/react", range: new Range(">=17") },
+    { name: "react", range: new Range("^17") },
+  ]));
+
+  assertEquals(mismatched, [
+    ["react", "Invalid notation. Only pinned and tilde (~) ranges allowed"],
+  ]);
+});
+
+Deno.test("will allow pinned versions", () => {
+  const mismatched = mismatches(matched_types([
+    { name: "@types/react", range: new Range("17") },
+    { name: "react", range: new Range("17") },
+  ]));
+
+  assertEquals(mismatched, []);
 });
 
 Deno.test("will error on invalid major ranges", () => {
   const mismatched = mismatches(matched_types([
-    ["@types/react", "~17.1"],
-    ["react", "~18.1"],
+    { name: "@types/react", range: new Range("~17.1") },
+    { name: "react", range: new Range("~18.1") },
   ]));
 
   assertEquals(mismatched, [
@@ -45,8 +69,8 @@ Deno.test("will error on invalid major ranges", () => {
 
 Deno.test("will error on invalid minor ranges", () => {
   const mismatched = mismatches(matched_types([
-    ["@types/react", "~17.1"],
-    ["react", "~17.0"],
+    { name: "@types/react", range: new Range("~17.1") },
+    { name: "react", range: new Range("~17.0") },
   ]));
 
   assertEquals(mismatched, [

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,7 +68,7 @@ const dependencies_from_package = parse_declared_dependencies(
 
 if (dependencies_from_package.length === 0) {
   if (verbose) {
-    console.info("╰ You have no dependencies and therefore no issues!");
+    console.info("╰─ You have no dependencies and therefore no issues!");
   }
   Deno.exit();
 }
@@ -84,13 +84,14 @@ if (duplicates.length > 0) {
 
 const definitely_typed_mismatches = mismatches(
   matched_types(dependencies_from_package),
+  { known_issues },
 );
 
 if (definitely_typed_mismatches.length > 0) {
   console.error(`╠╤ Mismatched ${colour.file("@types/*")} dependencies found!`);
   for (const [name, reason] of definitely_typed_mismatches) {
     console.error(
-      `║╰─ ${colour.invalid("✕")} ${colour.dependency(name)}: ${reason}`,
+      `║├─ ${colour.invalid("✕")} ${colour.dependency(name)}: ${reason}`,
     );
   }
 }
@@ -113,7 +114,9 @@ const number_of_mismatched_deps = count_unsatisfied_peer_dependencies(
 );
 
 const problems = number_of_mismatched_deps +
-  types_in_direct_dependencies.length + duplicates.length;
+  types_in_direct_dependencies.length +
+  duplicates.length +
+  definitely_typed_mismatches.length;
 
 console.info("║");
 console.info("╙───────────────────────────────────");

--- a/src/main.ts
+++ b/src/main.ts
@@ -10,7 +10,7 @@ import {
   format_dependencies,
 } from "./find_mismatches.ts";
 import { parse } from "https://deno.land/std@0.168.0/flags/mod.ts";
-import { filter_types } from "./check_types.ts";
+import { filter_types, matched_types, mismatches } from "./check_types.ts";
 
 const { _: [package_file], verbose, cache, errors } = parse(Deno.args, {
   boolean: ["verbose", "cache"],
@@ -59,13 +59,11 @@ if (types_in_direct_dependencies.length > 0) {
   );
 }
 
-const dependencies_tuple: [name: string, range: string][] = [
-  dependencies,
-  devDependencies,
-].map((_) => Object.entries(_)).flat();
-
 const dependencies_from_package = parse_declared_dependencies(
-  dependencies_tuple,
+  [
+    dependencies,
+    devDependencies,
+  ].flatMap(Object.entries),
 );
 
 if (dependencies_from_package.length === 0) {
@@ -81,6 +79,19 @@ if (duplicates.length > 0) {
   console.error(`╠╤ Duplicate dependencies found!`);
   for (const name of duplicates) {
     console.error(`║╰─ ${colour.invalid("✕")} ${colour.dependency(name)}`);
+  }
+}
+
+const definitely_typed_mismatches = mismatches(
+  matched_types(dependencies_from_package),
+);
+
+if (definitely_typed_mismatches.length > 0) {
+  console.error(`╠╤ Mismatched ${colour.file("@types/*")} dependencies found!`);
+  for (const [name, reason] of definitely_typed_mismatches) {
+    console.error(
+      `║╰─ ${colour.invalid("✕")} ${colour.dependency(name)}: ${reason}`,
+    );
   }
 }
 
@@ -125,7 +136,7 @@ if (problems === 0) {
   );
 }
 
-if (known_issues) {
+if (Object.keys(known_issues).length > 0) {
   console.info("");
   console.info(
     `${colour.subdued("□")} There are ${

--- a/src/parse_dependencies.ts
+++ b/src/parse_dependencies.ts
@@ -20,6 +20,7 @@ const package_parser = object({
   version: string(),
   dependencies: record(string()).optional(),
   devDependencies: record(string()).optional(),
+  peerDependencies: record(string()).optional(),
   known_issues: record(record(tuple([string(), string()]))).optional(),
 });
 
@@ -29,6 +30,7 @@ export const parse_package_info = (contents: unknown): Unrefined_dependency => {
     version,
     dependencies = {},
     devDependencies = {},
+    peerDependencies = {},
     known_issues = {},
   } = package_parser.parse(
     contents,
@@ -38,6 +40,7 @@ export const parse_package_info = (contents: unknown): Unrefined_dependency => {
     range: new Range(version),
     dependencies,
     devDependencies,
+    peerDependencies,
     known_issues,
   };
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,7 @@ export interface Dependency {
 export interface Unrefined_dependency extends Dependency {
   dependencies: Record<string, string>;
   devDependencies: Record<string, string>;
+  peerDependencies: Record<string, string>;
   known_issues: Record<string, Record<string, [from: string, to: string]>>;
 }
 


### PR DESCRIPTION
## What does this change?

Add a test for `@types/*` packages. Community types should have the same major.minor version as their associated package.

## How to test

Run against a `package.json` file

## How can we measure success?

Better health!

## Have we considered potential risks?

The known errors can be used to obfuscate real type safety problems. I could not think of a better way to acknowledge the current state of affairs.

## Images

<img width="639" alt="image" src="https://user-images.githubusercontent.com/76776/216057524-f5f0d25d-a7bf-4dd0-8d9c-ffae155b298c.png">